### PR TITLE
Replaced edgexfroundry with brand store's iotdevice-edgexfoundry

### DIFF
--- a/nuc-jcv-dangerous.json
+++ b/nuc-jcv-dangerous.json
@@ -106,10 +106,10 @@
             "id":"9IuGPw5BnC6jAgdi9O95WluQZqFEAi27"
         },
 	{
-	    "name": "edgexfoundry",
+	    "name": "iotdevice-edgexfoundry",
 	    "type": "app",
 	    "default-channel":"latest/stable",
-	    "id":"AZGf0KNnh8aqdkbGATNuRuxnt1GNRKkV"
+	    "id":"3GEp3VxaCUTBgPNSeFhd5OaFEoBtDBat"
 	}
     ]
 }

--- a/nuc-jcv.json
+++ b/nuc-jcv.json
@@ -107,10 +107,10 @@
             "id":"9IuGPw5BnC6jAgdi9O95WluQZqFEAi27"
         },
 	{
-	    "name": "edgexfoundry",
+	    "name": "iotdevice-edgexfoundry",
 	    "type": "app",
 	    "default-channel":"latest/stable",
-	    "id":"AZGf0KNnh8aqdkbGATNuRuxnt1GNRKkV"
+	    "id":"3GEp3VxaCUTBgPNSeFhd5OaFEoBtDBat"
 	}
     ]
 }


### PR DESCRIPTION
The ces demo is based on edgex 2.3, which is EOL and has been deleted from the global store. 
This modification allows to keep installing edgex 2.3 from the iotdevice-edgexfoundry snap.